### PR TITLE
Add the package-lock.json to gitigore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 /.nyc_output
 /coverage
 /node_modules/
+package-lock.json


### PR DESCRIPTION
Github raise security alerts because a locked dependencies in the lock file an I do think npm will resolve it so you might just wanna add it git ignore